### PR TITLE
Server was not reconnecting because it thought it was still connected

### DIFF
--- a/antenna-genius-server.js
+++ b/antenna-genius-server.js
@@ -34,6 +34,7 @@ module.exports = (RED) => {
                 this.log("TCP connection disconnected with the server.");
                 clearInterval(this.interval);
                 clearTimeout(this.timer);
+                this.connected = false;
 
                 if (this.updatesEventEmitter.listenerCount("closed") == 0) {
                     this.log(


### PR DESCRIPTION
`server` node was failing to reconnect when the AG dropped the connection (such as when changing settings).

The `setTimeout` call was working as expected, but when it called `connect()`, it will get short-circuited because `this.connected` was still `true`.
